### PR TITLE
Frontend nginx config for static files and basic auth

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 *
 
+!nginx/
 !*.conf

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 .PHONY: build
 build:
-	docker build --pull -t digitalmarketplace/base -f base.docker .
-	docker build --pull -t digitalmarketplace/base-api -f api.docker .
-	docker build --pull -t digitalmarketplace/base-frontend -f frontend.docker .
+	docker pull digitalmarketplace/base
+	docker build --cache-from digitalmarketplace/base -t digitalmarketplace/base -f base.docker .
+	docker build -t digitalmarketplace/base-api -f api.docker .
+	docker build -t digitalmarketplace/base-frontend -f frontend.docker .
 
 .PHONY: push
 push:

--- a/api.docker
+++ b/api.docker
@@ -1,5 +1,7 @@
 FROM digitalmarketplace/base
 
+COPY nginx/api /etc/nginx/sites-enabled/api
+
 ONBUILD COPY requirements.txt ${APP_DIR}
 ONBUILD RUN pip install --no-cache-dir -r requirements.txt
 

--- a/base.docker
+++ b/base.docker
@@ -8,11 +8,13 @@ RUN apk add --no-cache --virtual .build-deps git nodejs gcc g++ make python2-dev
 RUN pip install supervisor==3.3.1 awscli awscli-cwlogs && aws configure set plugins.cwlogs cwlogs
 
 COPY supervisord.conf /etc/supervisord.conf
-COPY nginx.conf /etc/nginx/nginx.conf
+COPY nginx/nginx.conf /etc/nginx/nginx.conf
 COPY uwsgi.conf /etc/uwsgi.conf
 COPY awslogs.conf /etc/awslogs.conf
 
-RUN mkdir -p ${APP_DIR} && chmod 777 /run
+COPY nginx/run.sh /nginx.sh
+
+RUN mkdir -p ${APP_DIR} && mkdir -p /etc/nginx/sites-enabled && chmod 777 /run
 WORKDIR ${APP_DIR}
 
 CMD ["supervisord", "--configuration", "/etc/supervisord.conf"]

--- a/frontend.docker
+++ b/frontend.docker
@@ -1,5 +1,7 @@
 FROM digitalmarketplace/base
 
+COPY nginx/frontend /etc/nginx/sites-enabled/frontend
+
 ONBUILD COPY requirements.txt ${APP_DIR}
 ONBUILD RUN pip install --no-cache-dir -r requirements.txt
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -39,6 +39,10 @@ http {
   server {
     listen 80;
 
+    location ~ ^(?:/[^/]+)?/static/(.+)$ {
+        alias /app/app/static/$1;
+    }
+
     location / {
       # auth_basic "Restricted";
       # auth_basic_user_file "/etc/nginx/conf/.htpasswd";

--- a/nginx/api
+++ b/nginx/api
@@ -1,0 +1,8 @@
+server {
+    listen 80;
+
+    location / {
+        include uwsgi_params;
+        uwsgi_pass unix:///run/uwsgi.sock;
+    }
+}

--- a/nginx/frontend
+++ b/nginx/frontend
@@ -1,0 +1,19 @@
+server {
+    listen 80;
+
+    location ~ ^(?:/[-a-z]+)?/static/(.+)$ {
+        alias /app/app/static/$1;
+    }
+
+    location ~ ^(?:/[-a-z]+)?/_status$ {
+        include uwsgi_params;
+        uwsgi_pass unix:///run/uwsgi.sock;
+    }
+
+    location / {
+        auth_basic "Restricted";
+        auth_basic_user_file "/etc/nginx/.htpasswd";
+        include uwsgi_params;
+        uwsgi_pass unix:///run/uwsgi.sock;
+    }
+}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -36,18 +36,6 @@ http {
 
   server_tokens off;
 
-  server {
-    listen 80;
+  include /etc/nginx/sites-enabled/*;
 
-    location ~ ^(?:/[^/]+)?/static/(.+)$ {
-        alias /app/app/static/$1;
-    }
-
-    location / {
-      # auth_basic "Restricted";
-      # auth_basic_user_file "/etc/nginx/conf/.htpasswd";
-      include uwsgi_params;
-      uwsgi_pass unix:///run/uwsgi.sock;
-    }
-  }
 }

--- a/nginx/run.sh
+++ b/nginx/run.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+echo "${PROXY_AUTH_CREDENTIALS}" >> /etc/nginx/.htpasswd
+
+exec /usr/sbin/nginx

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -2,7 +2,7 @@
 nodaemon = true
 
 [program:nginx]
-command = /usr/sbin/nginx
+command = /nginx.sh
 autostart = true
 autorestart = true
 stdout_logfile = /dev/stdout


### PR DESCRIPTION
 ### Serve static files from disk with nginx

Adds a location to the nginx config to serve all requests for
/static/ from /app/app/static directory.

Since the static URL prefix is different for each frontend app
(eg /static/ for buyer frontend and /admin/static/ for admin)
we use a regex location match to match any URLs that start with
either `/static/` or `/*/static/`.

### Make base image pull and reuse cache from registry during build

By default, docker will only use cached layers that were created
locally when running the image build. This means that each time
the base image is build on a machine that didn't build the previous
docker will run the image creation steps from scratch, which is
likely to result in new layer snapshots.

In order to avoid this, we're pulling the latest base image from
Docker Hub and then using it as cache source during the build.

We don't need to do this for base-api and base-frontend at the
moment since they're not creating layers that can differ a lot
between separate runs (ie they're not installing packages or
modifying lots of files in non-repeatable ways).

### Add basic auth check for frontend apps nginx config

Running nginx next to the application servers allows us to replace
the route service with the auth check in the nginx config.

Authentication details are set from the PROXY_AUTH_CREDENTIALS
environment variable during the startup by the wrapper nginx
script. PROXY_AUTH_CREDENTIALS should follow the
"<username>:<password apr1 hash>" format.

Since we only want the auth check for the frontend apps we need to
split the configs into api and frontend.