### PR TITLE
Remove g++ dependency

### DIFF
--- a/base.docker
+++ b/base.docker
@@ -3,7 +3,7 @@ FROM alpine:3.5
 ENV APP_DIR /app
 
 RUN apk add --no-cache python2 py2-pip nginx uwsgi-python postgresql-dev libffi-dev
-RUN apk add --no-cache --virtual .build-deps git nodejs gcc g++ make python2-dev musl-dev
+RUN apk add --no-cache --virtual .build-deps git nodejs gcc make python2-dev musl-dev
 
 RUN pip install supervisor==3.3.1 awscli awscli-cwlogs && aws configure set plugins.cwlogs cwlogs
 


### PR DESCRIPTION
Version 3 of node-sass is being used in the frontend apps. It recognises
Alpine as a distribution so it doesn't need to recompile the bindings
to libsass. This means we don't need g++.