### PR TITLE
Add ca-certificates package to validate SSL certs

### DIFF
--- a/base.docker
+++ b/base.docker
@@ -2,7 +2,7 @@ FROM alpine:3.5
 
 ENV APP_DIR /app
 
-RUN apk add --no-cache python2 py2-pip nginx uwsgi-python postgresql-dev libffi-dev
+RUN apk add --no-cache ca-certificates python2 py2-pip nginx uwsgi-python postgresql-dev libffi-dev
 RUN apk add --no-cache --virtual .build-deps git nodejs gcc make python2-dev musl-dev
 
 RUN pip install supervisor==3.3.1 awscli awscli-cwlogs && aws configure set plugins.cwlogs cwlogs


### PR DESCRIPTION
boto raises an SSL validation error when trying to connect to S3
since CA certificate chains are not available on Alpine by default.

Installing ca-certificates package fixes the issue.