### PR TITLE
Switch to debian:jessie based image for glibc strftime

### DIFF
--- a/api.docker
+++ b/api.docker
@@ -7,7 +7,5 @@ ONBUILD RUN pip install --no-cache-dir -r requirements.txt
 
 ONBUILD COPY . ${APP_DIR}
 
-ONBUILD RUN apk del .build-deps
-
 ONBUILD ARG release_name
 ONBUILD RUN echo ${release_name} > ${APP_DIR}/version_label

--- a/awslogs/run.sh
+++ b/awslogs/run.sh
@@ -2,4 +2,4 @@
 
 sed -i -e "s/{DM_ENVIRONMENT}/$DM_ENVIRONMENT/g" -e "s/{DM_APP_NAME}/$DM_APP_NAME/g" /etc/awslogs.conf
 
-exec /usr/bin/aws logs push --region eu-west-1 --config-file /etc/awslogs.conf
+exec /usr/local/bin/aws logs push --region eu-west-1 --config-file /etc/awslogs.conf

--- a/base.docker
+++ b/base.docker
@@ -1,11 +1,22 @@
-FROM alpine:3.5
+FROM python:2.7.13-slim
 
 ENV APP_DIR /app
 
-RUN apk add --no-cache ca-certificates python2 py2-pip nginx uwsgi-python postgresql-dev libffi-dev
-RUN apk add --no-cache --virtual .build-deps git nodejs gcc make python2-dev musl-dev
+ENV NODE_VERSION 6.10.3
 
-RUN pip install supervisor==3.3.1 awscli awscli-cwlogs && aws configure set plugins.cwlogs cwlogs
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends nginx \
+                    libpcre3-dev libpq-dev libffi-dev gcc make git curl xz-utils && \
+    curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" && \
+    tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /usr/local --strip-components=1 && \
+    rm "node-v$NODE_VERSION-linux-x64.tar.xz" && \
+    rm -rf /var/lib/apt/lists/* && \
+    pip install --no-cache-dir uwsgi supervisor==3.3.1 awscli awscli-cwlogs && \
+    aws configure set plugins.cwlogs cwlogs && \
+    mkdir -p ${APP_DIR} && \
+    rm -f /etc/nginx/sites-enabled/* && \
+    mkdir -p /var/log/digitalmarketplace && \
+    chmod 777 /run
 
 COPY supervisord.conf /etc/supervisord.conf
 COPY nginx/nginx.conf /etc/nginx/nginx.conf
@@ -14,11 +25,6 @@ COPY awslogs/awslogs.conf /etc/awslogs.conf
 
 COPY nginx/run.sh /nginx.sh
 COPY awslogs/run.sh /awslogs.sh
-
-RUN mkdir -p ${APP_DIR} && \
-    mkdir -p /etc/nginx/sites-enabled && \
-    mkdir -p /var/log/digitalmarketplace && \
-    chmod 777 /run
 
 WORKDIR ${APP_DIR}
 

--- a/frontend.docker
+++ b/frontend.docker
@@ -15,7 +15,5 @@ ONBUILD COPY . ${APP_DIR}
 
 ONBUILD RUN ./scripts/build.sh
 
-ONBUILD RUN apk del .build-deps
-
 ONBUILD ARG release_name
 ONBUILD RUN echo ${release_name} > ${APP_DIR}/version_label

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -37,6 +37,9 @@ http {
 
   server_tokens off;
 
+  # Set max request size (up to 4 files x 10Mb size limit)
+  client_max_body_size 40m;
+
   include /etc/nginx/sites-enabled/*;
 
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,6 +1,6 @@
 daemon off;
 pid /run/nginx.pid;
-user nginx;
+user www-data www-data;
 
 worker_processes 4;
 

--- a/uwsgi.conf
+++ b/uwsgi.conf
@@ -1,9 +1,11 @@
 [uwsgi]
-uid = nginx
+uid = www-data
+gid = www-data
 module = application:application
 
-plugins = /usr/lib/uwsgi/python
 socket = /run/uwsgi.sock
 
+single-interpreter = true
+enable-threads = true
+
 processes = 4
-threads = 1


### PR DESCRIPTION
We've run into an issue with Alpine's musl libc strftime. Using a
non-zero-padded strftime format (eg "%-d") returns an empty string
on alpine (both on apk-installed python and python:alpine image).

Switching to debian brings our PaaS closer to existing environments
(Travis is running Ubuntu 12.04/14.04, EB is running Amazon Linux).

We're using python:2.7.13-slim image as base. It's build on top of
debian jessie, but compiles the specified python version separate
from the system python. Since python is our main runtime it makes
sense to use as a base image. The image also provides pip 9.0.1.

We're setting up the current LTS node version for our frontend
build. Since node version provided by debian is much older, we're
downloading node archive from nodejs instead.

uwsgi is installed as pip package to bring in a newer version.

We also don't need to create the sites-enabled nginx folder since
it already created by the debian nginx package. Instead, we remove
the sites-enabled/default configuration.

The rest of the setup is similar to Alpine.