### PR TITLE
Explicitly specify `latest` tag in docker push

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,11 @@ build:
 
 .PHONY: push
 push:
-	docker push digitalmarketplace/base
 	docker push digitalmarketplace/base:${VERSION}
+	docker push digitalmarketplace/base:latest
 
-	docker push digitalmarketplace/base-api
 	docker push digitalmarketplace/base-api:${VERSION}
+	docker push digitalmarketplace/base-api:latest
 
-	docker push digitalmarketplace/base-frontend
 	docker push digitalmarketplace/base-frontend:${VERSION}
+	docker push digitalmarketplace/base-frontend:latest


### PR DESCRIPTION
`docker push` now seems to upload all existing tagged images in the
repository if the tag isn't explicitly specified.

Since we don't want to accidentally overwrite previous versions,
we should explicitly push only the current version and set latest
tag to match it.