### PR TITLE
Reorder builds in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ define push-image
 endef
 
 .PHONY: build-all
-build-all: build-py3 build-py2
+build-all: build-py2 build-py3
 
 .PHONY: build-py3
 build-py3:
@@ -39,7 +39,7 @@ build-py2:
 	$(call build-image)
 
 .PHONY: push-all
-push-all: push-py3 push-py2
+push-all: push-py2 push-py3
 
 .PHONY: push-py3
 push-py3:


### PR DESCRIPTION
If you build python 2 images after python 3, there's a risk that you'll
push python 2 with the `:latest` tag when using `make push-all`.

By building python3 second it helps to mitigate that risk. It is still
possible however if you used `make build-py2` just before pushing. So
don't.