### PR TITLE
nginx: add epochTime to logs to allow us to capture fractional seconds

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -19,6 +19,7 @@ http {
                          ' "remoteHost": "$remote_addr", '
                          ' "user": "$remote_user", '
                          ' "time": "$time_local", '
+                         ' "epochTime": "$msec", '
                          ' "request": "$request", '
                          ' "status": $status, '
                          ' "size": $body_bytes_sent, '


### PR DESCRIPTION
As mentioned elsewhere nginx for the time being is unable to log fractional seconds in any format other than epoch-time. We may be able to post-process the logs to be able to handle this, splicing together the iso timestamp with the fractional part of the epoch timestamp - that's something to investigate, but the first step of this is to actually have the data.