### PR TITLE
Pin versions of our main top-level libraries

### DIFF
--- a/base.docker
+++ b/base.docker
@@ -4,6 +4,10 @@ ENV APP_DIR /app
 
 ENV NODE_VERSION 6.12.2
 ENV YARN_VERSION 1.3.2-1
+ENV SUPERVISOR_VERSION 3.3.3
+ENV UWSGI_VERSION 2.0.15
+ENV AWSCLI_VERSION 1.14.31
+ENV AWSCLI_CWLOGS_VERSION 1.4.4
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends nginx \
@@ -17,8 +21,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends yarn=${YARN_VERSION} && \
     rm -rf /var/lib/apt/lists/* && \
-    /usr/bin/python2.7 /usr/bin/pip install supervisor==3.3.3 && \
-    pip install --no-cache-dir uwsgi awscli awscli-cwlogs && \
+    /usr/bin/python2.7 /usr/bin/pip install supervisor==${SUPERVISOR_VERSION} && \
+    /usr/local/bin/pip3 install --no-cache-dir uwsgi==${UWSGI_VERSION} awscli==${AWSCLI_VERSION} awscli-cwlogs==${AWSCLI_CWLOGS_VERSION} && \
     aws configure set plugins.cwlogs cwlogs && \
     mkdir -p ${APP_DIR} && \
     rm -f /etc/nginx/sites-enabled/* && \


### PR DESCRIPTION
## Summary
Pin the versions of our main libraries so that we don't accidentally do a major/minor upgrade that breaks our deploys. I've taken these versions from what is currently installed in the latest frontend docker image. Also clarifies that we are using pip3/python3 to install uwsgi/awscli. I looked into upgrading Supervisor to Python3 and while it seems it is mostly compatible, they haven't explicitly released version 4.0.0 that comes with official support, so leaving it as-is for now. https://github.com/Supervisor/supervisor/issues/510

```
root@556a0412-e832-4ac3-41c9-68e7:/# /usr/local/bin/pip list
DEPRECATION: The default format will switch to columns in the future. You can use --format=(legacy|columns) (or define a format=(legacy|columns) in your pip.conf under the [list] section) to disable this warning.
awscli (1.14.31)
awscli-cwlogs (1.4.4)
botocore (1.8.35)
colorama (0.3.7)
docutils (0.14)
jmespath (0.9.3)
pip (9.0.1)
pyasn1 (0.4.2)
python-dateutil (2.6.1)
PyYAML (3.12)
rsa (3.4.2)
s3transfer (0.1.12)
setuptools (38.2.4)
six (1.11.0)
uWSGI (2.0.15)
wheel (0.30.0)
```

Dependencies of these libraries are still not pinned, so theoretically things could still break, but at least it's a lot less likely.

## Ticket
https://trello.com/c/Y6H3QWlM/315-uwsgi-version-should-be-pinned
