### PR TITLE
Fix Makefile by adding BUILD_DATE to Docker image metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BUILD_DATE := $(shell date -u '+%Y%m%dT%H%M%SZ')
 .PHONY: build
 build:
 	docker pull digitalmarketplace/base
-	docker build --cache-from digitalmarketplace/base -t digitalmarketplace/base -f base.docker .
+	docker build --pull --cache-from digitalmarketplace/base -t digitalmarketplace/base -f base.docker .
 	docker tag digitalmarketplace/base digitalmarketplace/base:${BUILD_VERSION}
 	docker tag digitalmarketplace/base digitalmarketplace/base:${BUILD_VERSION}-${BUILD_DATE}
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 BUILD_VERSION := $(shell cat VERSION)
-BUILD_DATE := $(shell date -u '+%Y%m%dT%H%M%SZ')
 
 .PHONY: build
 build:
+	$(eval BUILD_DATE := $(shell date -u '+%Y%m%dT%H%M%SZ'))
+	$(eval BUILD_ARGS := --build-arg BUILD_DATE=${BUILD_DATE} --build-arg BUILD_VERSION=${BUILD_VERSION})
+
 	docker pull digitalmarketplace/base
-	docker build --pull --cache-from digitalmarketplace/base -t digitalmarketplace/base -f base.docker .
+	docker build --pull --cache-from digitalmarketplace/base ${BUILD_ARGS} -t digitalmarketplace/base -f base.docker .
 	docker tag digitalmarketplace/base digitalmarketplace/base:${BUILD_VERSION}
 	docker tag digitalmarketplace/base digitalmarketplace/base:${BUILD_VERSION}-${BUILD_DATE}
 
@@ -18,6 +20,8 @@ build:
 
 .PHONY: push
 push:
+	$(eval BUILD_DATE := $(shell docker inspect --format '{{.Config.Labels.BUILD_DATE}}' digitalmarketplace/base))
+
 	docker push digitalmarketplace/base:${BUILD_VERSION}
 	docker push digitalmarketplace/base:${BUILD_VERSION}-${BUILD_DATE}
 	docker push digitalmarketplace/base:latest

--- a/base.docker
+++ b/base.docker
@@ -1,5 +1,8 @@
 FROM python:3.6-slim-stretch
 
+ARG BUILD_DATE
+ARG BUILD_VERSION
+
 ENV APP_DIR /app
 
 ENV DEP_NODE_VERSION 6.12.2
@@ -36,6 +39,9 @@ COPY awslogs/awslogs.conf /etc/awslogs.conf
 
 COPY nginx/run.sh /nginx.sh
 COPY awslogs/run.sh /awslogs.sh
+
+LABEL BUILD_DATE=${BUILD_DATE}
+LABEL BUILD_VERSION=${BUILD_VERSION}
 
 WORKDIR ${APP_DIR}
 


### PR DESCRIPTION
This PR adds the BUILD_VERSION and BUILD_DATE timestamp to the Docker images metadata, which achieves two things:

  1. It means that the Makefile actually works now (:woops:)
  2. Images have a persistent record of when they were built and which version of the Dockerfile they were built with which will survive even if the tags get messed up