### PR TITLE
WIP 295-add-custom-python-metrics-to-brief-responses-frontend

### DIFF
--- a/nginx/frontend
+++ b/nginx/frontend
@@ -5,7 +5,7 @@ server {
         alias /app/app/static/$1;
     }
 
-    location ~ ^(?:/[-a-z/]+)?/_status$ {
+    location ~ ^(?:/[-a-z/]+)?/(_status|_metrics)$ {
         include uwsgi_params;
         uwsgi_pass unix:///run/uwsgi.sock;
     }


### PR DESCRIPTION

* Do not basic-auth _metrics endpoint, this should be done with paas IP whitelisting


See:
https://serverfault.com/questions/564127/nginx-location-regex-for-multiple-paths-with-backend
https://trello.com/c/IOBExody/295-add-custom-python-metrics-to-brief-responses-frontend
https://reliability-engineering.cloudapps.digital/monitoring-alerts.html#ip-whitelist-your-applications-metrics-endpoint