### PR TITLE
Update to Node 10.23.0

### DIFF
--- a/frontend.docker
+++ b/frontend.docker
@@ -1,6 +1,6 @@
 FROM digitalmarketplace/base
 
-ENV DEP_NODE_VERSION 10.22.0
+ENV DEP_NODE_VERSION 10.23.0
 
 RUN /usr/bin/curl -SLO "https://nodejs.org/dist/v${DEP_NODE_VERSION}/node-v${DEP_NODE_VERSION}-linux-x64.tar.xz" && \
     test $(sha256sum node-v${DEP_NODE_VERSION}-linux-x64.tar.xz | cut -d " " -f 1) = ddf33e038c593d6df36b1dd4b25c1b6fa8230c615e6312ad33e80ef863e4a74f && \


### PR DESCRIPTION
Trello: https://trello.com/c/nbQDLaxV/2096-resolve-dependabot-prs

To pick up a CVE fix (CVE-2020-8252). I don't think there have been any changes that should cause us problems.