### PR TITLE
Update Node binary SHA sum

### DIFF
--- a/frontend.docker
+++ b/frontend.docker
@@ -3,7 +3,7 @@ FROM digitalmarketplace/base
 ENV DEP_NODE_VERSION 14.17.3
 
 RUN /usr/bin/curl -SLO "https://nodejs.org/dist/v${DEP_NODE_VERSION}/node-v${DEP_NODE_VERSION}-linux-x64.tar.xz" && \
-    test $(sha256sum node-v${DEP_NODE_VERSION}-linux-x64.tar.xz | cut -d " " -f 1) = 85a89d2f68855282c87851c882d4c4bbea4cd7f888f603722f0240a6e53d89df && \
+    test $(sha256sum node-v${DEP_NODE_VERSION}-linux-x64.tar.xz | cut -d " " -f 1) = d659d78144042a1801f35dd611d0fab137e841cde902b2c6a821163a5e36f105 && \
     /bin/tar -xJf "node-v${DEP_NODE_VERSION}-linux-x64.tar.xz" -C /usr/local --strip-components=1 && \
     /bin/rm "node-v${DEP_NODE_VERSION}-linux-x64.tar.xz"
 


### PR DESCRIPTION
In #83 we updated the version of Node to take some security fixes, however we forgot to also update the SHA sum we check the downloaded binary against. Update this to the correct string.

There's no need to update the version tag - we've not been able to build and release 10.0.2 yet.

To check this is correct, run the below commands which are the minimum required to download it in the docker image:

```
~  $ docker run -it --rm python:3.6-slim-buster /bin/bash
root@04cfa8d6f9a8:/# export DEP_NODE_VERSION=14.17.3
root@04cfa8d6f9a8:/# /usr/bin/apt-get update
Get:1 http://security.debian.org/debian-security buster/updates InRelease [65.4 kB]
.....
root@04cfa8d6f9a8:/# /usr/bin/apt-get install -y --no-install-recommends curl
.....
Setting up curl (7.64.0-4+deb10u2) ...
Processing triggers for libc-bin (2.28-10) ...
root@04cfa8d6f9a8:/# /usr/bin/curl -SLO "https://nodejs.org/dist/v${DEP_NODE_VERSION}/node-v${DEP_NODE_VERSION}-linux-x64.tar.xz" &&     test $(sha256sum node-v${DEP_NODE_VERSION}-linux-x64.tar.xz | cut -d " " -f 1) = 85a89d2f68855282c87851c882d4c4bbea4cd7f888f603722f0240a6e53d89df &&     /bin/tar -xJf "node-v${DEP_NODE_VERSION}-linux-x64.tar.xz" -C /usr/local --strip-components=1 &&     /bin/rm "node-v${DEP_NODE_VERSION}-linux-x64.tar.xz"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 20.7M  100 20.7M    0     0   505k      0  0:00:42  0:00:42 --:--:--  545k
root@04cfa8d6f9a8:/# ls
bin  boot  dev    etc  home  lib    lib64  media  mnt  node-v14.17.3-linux-x64.tar.xz  opt    proc  root  run  sbin  srv  sys  tmp  usr  var
root@04cfa8d6f9a8:/# sha256sum node-v${DEP_NODE_VERSION}-linux-x64.tar.xz | cut -d " " -f 1
d659d78144042a1801f35dd611d0fab137e841cde902b2c6a821163a5e36f105
```

https://trello.com/c/iFGhnPkx/2277-frontend-docker-base-image-isnt-building-with-node-14173