### PR TITLE
Add Github action to build Docker images

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,10 @@ jobs:
       - name: Build Docker base image
         run: |
           docker pull digitalmarketplace/base
-          docker build --pull --cache-from digitalmarketplace/base --build-arg BUILD_DATE=${{ env.build_date }} --build-arg BUILD_VERSION=${{ env.build_version }} -t digitalmarketplace/base -f base.docker .
+          docker build --pull --cache-from digitalmarketplace/base --build-arg BUILD_DATE=${{ env.build_date }} --build-arg BUILD_VERSION=${{ env.build_version }} --tag digitalmarketplace/base --file base.docker .
 
       - name: Build API image
-        run: docker build -f api.docker .
+        run: docker build --file api.docker .
 
       - name: Build Frontend image
-        run: docker build -f frontend.docker .
+        run: docker build --file frontend.docker .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: Test
+on: [pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+
+      - name: Set common environment variables
+        run: |
+          echo "build_date=$(date -u '+%Y%m%dT%H%M%SZ')" >> $GITHUB_ENV
+          echo "build_version=$(cat VERSION)" >> $GITHUB_ENV
+
+      - name: Build Docker base image
+        run: |
+          docker pull digitalmarketplace/base
+          docker build --pull --cache-from digitalmarketplace/base --build-arg BUILD_DATE=${{ env.build_date }} --build-arg BUILD_VERSION=${{ env.build_version }} -t digitalmarketplace/base -f base.docker .
+
+      - name: Build API image
+        run: docker build -f api.docker .
+
+      - name: Build Frontend image
+        run: docker build -f frontend.docker .


### PR DESCRIPTION
So we don't merge anything that breaks the image. 

This just tests that the images can be built successfully, but I think that should be sufficient as a pre-merge check. It's pretty tough to run the base images on their own without an app to check that eg. nginx starts, the image serves some html etc, and I'm not sure it's worth the effort.

https://trello.com/c/iFGhnPkx/2277-frontend-docker-base-image-isnt-building-with-node-14173